### PR TITLE
Add prism as front matter option for blog posts, default is false

### DIFF
--- a/_includes/layouts/post.html
+++ b/_includes/layouts/post.html
@@ -6,11 +6,6 @@ layout: layouts/default.html
     .content-container {
         background-color: var(--content-bg-color);
     }
-
-/* PrismJS 1.29.0
-https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash */
-code[class*=language-],pre[class*=language-]{color:#000;background:0 0;text-shadow:0 1px #fff;font-family:Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;font-size:1em;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}code[class*=language-] ::-moz-selection,code[class*=language-]::-moz-selection,pre[class*=language-] ::-moz-selection,pre[class*=language-]::-moz-selection{text-shadow:none;background:#b3d4fc}code[class*=language-] ::selection,code[class*=language-]::selection,pre[class*=language-] ::selection,pre[class*=language-]::selection{text-shadow:none;background:#b3d4fc}@media print{code[class*=language-],pre[class*=language-]{text-shadow:none}}pre[class*=language-]{padding:1em;margin:.5em 0;overflow:auto}:not(pre)>code[class*=language-],pre[class*=language-]{background:#f5f2f0}:not(pre)>code[class*=language-]{padding:.1em;border-radius:.3em;white-space:normal}.token.cdata,.token.comment,.token.doctype,.token.prolog{color:#708090}.token.punctuation{color:#999}.token.namespace{opacity:.7}.token.boolean,.token.constant,.token.deleted,.token.number,.token.property,.token.symbol,.token.tag{color:#905}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#690}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url{color:#9a6e3a;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.class-name,.token.function{color:#dd4a68}.token.important,.token.regex,.token.variable{color:#e90}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
-
 </style>
 
 <article class="pr-p0">
@@ -22,4 +17,11 @@ code[class*=language-],pre[class*=language-]{color:#000;background:0 0;text-shad
     </div>
 </article>
 
-<script src="/js/prism.js"></script>
+{% if prism %}
+<style>
+  /* PrismJS 1.29.0
+  https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash */
+  code[class*=language-],pre[class*=language-]{color:#000;background:0 0;text-shadow:0 1px #fff;font-family:Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;font-size:1em;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}code[class*=language-] ::-moz-selection,code[class*=language-]::-moz-selection,pre[class*=language-] ::-moz-selection,pre[class*=language-]::-moz-selection{text-shadow:none;background:#b3d4fc}code[class*=language-] ::selection,code[class*=language-]::selection,pre[class*=language-] ::selection,pre[class*=language-]::selection{text-shadow:none;background:#b3d4fc}@media print{code[class*=language-],pre[class*=language-]{text-shadow:none}}pre[class*=language-]{padding:1em;margin:.5em 0;overflow:auto}:not(pre)>code[class*=language-],pre[class*=language-]{background:#f5f2f0}:not(pre)>code[class*=language-]{padding:.1em;border-radius:.3em;white-space:normal}.token.cdata,.token.comment,.token.doctype,.token.prolog{color:#708090}.token.punctuation{color:#999}.token.namespace{opacity:.7}.token.boolean,.token.constant,.token.deleted,.token.number,.token.property,.token.symbol,.token.tag{color:#905}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#690}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url{color:#9a6e3a;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.class-name,.token.function{color:#dd4a68}.token.important,.token.regex,.token.variable{color:#e90}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
+  </style>
+  <script src="/js/prism.js"></script>
+{% endif %}

--- a/_posts/2022-11-28-extracting-fuel-moisture-data-from-rasters.md
+++ b/_posts/2022-11-28-extracting-fuel-moisture-data-from-rasters.md
@@ -1,6 +1,7 @@
 ---
 title: Extracting California fuel moisture data from Forest Service rasters
 description: Using open source Python and Javascript tools to extract data out of raster images and into GeoJSON files
+prism: true
 ---
 
 The US Forest Service has a way of measuring dead fuel moisture across the country, which is an important input in the complicated equations to better understand wildfire behavior. They publish it as a raster image but I want machine-readable, geospatial data. Bummer.

--- a/_posts/2022-12-18-more-stable-scrapers-with-recursive-promises.md
+++ b/_posts/2022-12-18-more-stable-scrapers-with-recursive-promises.md
@@ -1,6 +1,7 @@
 ---
 title: Promises for more stability
 description: Javascript Promises make it easy to add retry behavior to web scrapers so they crash less
+prism: true
 ---
 
 If you build enough web scrapers you’ll run into a situation where you have hundreds or thousands of URLs to churn through but the scraper breaks after hour 4 on page 1,387 because the request bailed for some reason and you didn’t catch the error. It’s a bummer, especially since it usually crushes that wonderful feeling of watching a robot do something repetitive on your behalf. _Sigh_.

--- a/_posts/2023-01-03-year-in-soil-moisture.md
+++ b/_posts/2023-01-03-year-in-soil-moisture.md
@@ -1,6 +1,7 @@
 ---
 title: How to turn a directory full of images into an animated GIF
-description: I used ImageMagick and a git scraper to look at 2022's soil moisture 
+description: I used ImageMagick and a git scraper to look at 2022's soil moisture
+prism: true
 ---
 
 It's been raining a lot here in Sacramento and soil moisture is something people are talking to each other about. It's weird. And wet.

--- a/_posts/_posts.json
+++ b/_posts/_posts.json
@@ -1,5 +1,6 @@
 {
     "layout": "layouts/post.html",
     "permalink": "/blog/{{ page.fileSlug }}/",
-    "tags": "posts"
+    "tags": "posts",
+    "prism": false
 }


### PR DESCRIPTION
[Prism](https://prismjs.com/) isn't needed by all the pages, but is still shipped by default. This adds a front matter option to control whether the library's JS and CSS get loaded on a per post basis.

Closes #36